### PR TITLE
Constants conflict

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -12,9 +12,15 @@
 use Symfony\Polyfill\Mbstring as p;
 
 if (!function_exists('mb_strlen')) {
-    define('MB_CASE_UPPER', 0);
-    define('MB_CASE_LOWER', 1);
-    define('MB_CASE_TITLE', 2);
+    if (!defined('MB_CASE_UPPER')) {
+        define('MB_CASE_UPPER', 0);
+    }
+    if (!defined('MB_CASE_LOWER')) {
+        define('MB_CASE_LOWER', 1);
+    }
+    if (!defined('MB_CASE_TITLE')) {
+        define('MB_CASE_TITLE', 2);
+    }
 
     function mb_convert_encoding($s, $to, $from = null) { return p\Mbstring::mb_convert_encoding($s, $to, $from); }
     function mb_decode_mimeheader($s) { return p\Mbstring::mb_decode_mimeheader($s); }


### PR DESCRIPTION
I recently installed php 7 on my computer without mbstring but when I ran some tests I had an error:
```
PHPUnit_Framework_Exception: PHP Notice:  Constant MB_CASE_UPPER already defined in /.../vendor/symfony/polyfill-mbstring/bootstrap.php on line 15
```

So I simply add checks before defining those constants.