### PR TITLE
Use null-coalesce instead of null-coalesce-equals

### DIFF
--- a/bootstrap80.php
+++ b/bootstrap80.php
@@ -122,7 +122,7 @@ if (!function_exists('mb_chr')) {
     function mb_chr(int $codepoint, string $encoding = null): string|false { return p\Mbstring::mb_chr($codepoint, $encoding); }
 }
 if (!function_exists('mb_scrub')) {
-    function mb_scrub(string $string, string $encoding = null): string { $encoding ??= mb_internal_encoding(); return mb_convert_encoding($string, $encoding, $encoding); }
+    function mb_scrub(string $string, string $encoding = null): string { $encoding = $encoding ?? mb_internal_encoding(); return mb_convert_encoding($string, $encoding, $encoding); }
 }
 if (!function_exists('mb_str_split')) {
     function mb_str_split(string $string, int $length = 1, string $encoding = null): array { return p\Mbstring::mb_str_split($string, $length, $encoding); }


### PR DESCRIPTION
The use of the PHP 8.0 only null-coalesce-equals (`??=`) means that this file causes Psalm to see it as a parse error for projects not yet migrated to PHP 8. There is currently no way to avoid this, as psalm considers a parse error an unignorable error, even though in this case the file would never be included unless it actually is running on PHP 8.0.

The only way to avoid this is to set the entire project as PHP 8.0 but then you wouldn't be notified of legitimate issues when deploying to PHP 7.x.

It's a simple change from `$a ??= $b` to `$a = $a ?? $b` form.