### PR TITLE
Fixes compatibility two polyfill functions with their behavior in mbsting extension in php 8.0

### DIFF
--- a/bootstrap80.php
+++ b/bootstrap80.php
@@ -45,7 +45,7 @@ if (!function_exists('mb_check_encoding')) {
     function mb_check_encoding(array|string|null $value = null, string $encoding = null): bool { return p\Mbstring::mb_check_encoding($value, $encoding); }
 }
 if (!function_exists('mb_detect_encoding')) {
-    function mb_detect_encoding(string $string, array|string|null $encodings = null, bool $strict = false): string|false { return p\Mbstring::mb_detect_encoding($string, $encodings, $strict); }
+    function mb_detect_encoding(string|null $string, array|string|null $encodings = null, bool $strict = false): string|false { return p\Mbstring::mb_detect_encoding($string, $encodings, $strict); }
 }
 if (!function_exists('mb_detect_order')) {
     function mb_detect_order(array|string|null $encoding = null): array|bool { return p\Mbstring::mb_detect_order($encoding); }
@@ -99,7 +99,7 @@ if (!function_exists('mb_http_output')) {
     function mb_http_output(string $encoding = null): string|bool { return p\Mbstring::mb_http_output($encoding); }
 }
 if (!function_exists('mb_strwidth')) {
-    function mb_strwidth(string $string, string $encoding = null): int { return p\Mbstring::mb_strwidth($string, $encoding); }
+    function mb_strwidth(string|null $string, string $encoding = null): int { return p\Mbstring::mb_strwidth($string, $encoding); }
 }
 if (!function_exists('mb_substr_count')) {
     function mb_substr_count(string $haystack, string $needle, string $encoding = null): int { return p\Mbstring::mb_substr_count($haystack, $needle, $encoding); }


### PR DESCRIPTION
I tried to use symfony/console in my project. I use php 8.0 without mbstring ext. When console script runs without arguments I get this two fatals
PHP Fatal error:  Uncaught TypeError: mb_detect_encoding(): Argument #1 ($string) must be of type string, null given
PHP Fatal error:  Uncaught TypeError: mb_strwidth(): Argument #1 ($string) must be of type string, null given

In mbstring ext these functions returns string (5) 'ASCII' if null passed.
