### PR TITLE
PHP 8.2.0 compatibility fix

### DIFF
--- a/Mbstring.php
+++ b/Mbstring.php
@@ -80,7 +80,7 @@ final class Mbstring
 
     public static function mb_convert_encoding($s, $toEncoding, $fromEncoding = null)
     {
-        if (\is_array($fromEncoding) || (null !== $fromEncoding && false !== strpos($fromEncoding, ','))) {
+        if (!is_null($fromEncoding) && ((\is_array($fromEncoding) || false !== strpos($fromEncoding, ',')))) {
             $fromEncoding = self::mb_detect_encoding($s, $fromEncoding);
         } else {
             $fromEncoding = self::getEncoding($fromEncoding);


### PR DESCRIPTION
This bugfix fixes the 8.2.0 compatibility issue

_Deprecated:  strpos(): Passing null to parameter # 1 ($haystack) of type string is deprecated in Mbstring.php on line 83_