### PR TITLE
Add missing iconv requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "php": ">=7.1"
+        "php": ">=7.1",
+        "ext-iconv": "*"
     },
     "provide": {
         "ext-mbstring": "*"


### PR DESCRIPTION
```
PHP Fatal error:  Uncaught Error: Call to undefined function Symfony\Polyfill\Mbstring\iconv() in phar:///php-cs-fixer.phar/vendor/symfony/polyfill-mbstring/Mbstring.php:116
Stack trace:
#0 phar:///php-cs-fixer.phar/vendor/symfony/polyfill-mbstring/bootstrap80.php(15): Symfony\Polyfill\Mbstring\Mbstring::mb_convert_encoding()
#1 phar:///php-cs-fixer.phar/vendor/symfony/console/Application.php(1241): mb_convert_encoding()
#2 phar:///php-cs-fixer.phar/vendor/symfony/console/Application.php(869): Symfony\Component\Console\Application->splitStringByWidth()
#3 phar:///php-cs-fixer.phar/vendor/symfony/console/Application.php(840): Symfony\Component\Console\Application->doRenderThrowable()
#4 phar:///php-cs-fixer.phar/vendor/symfony/console/Application.php(154): Symfony\Component\Console\Application->renderThrowable()
#5 phar:///php-cs-fixer.phar/vendor/symfony/console/Application.php(177): Symfony\Component\Console\Application->Symfony\Component\Console\{closure}()
#6 /php-cs-fixer.phar(102): Symfony\Component\Console\Application->run()
#7 {main}
  thrown in phar:///php-cs-fixer.phar/vendor/symfony/polyfill-mbstring/Mbstring.php on line 116
```